### PR TITLE
Fix Puppetfile for use with latest r10k

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -100,4 +100,5 @@ mod 'puppetlabs-support_tasks',         '1.1.2'
 mod 'inkblot-bind',                     '7.4.0'
 mod 'saz-resolv_conf',                  '4.2.1'
 mod 'nessus_agent_tasks',
-  :git => 'https://github.com/kinners00/nessus_agent_tasks'
+  :git => 'https://github.com/kinners00/nessus_agent_tasks',
+  :ref => 'master'


### PR DESCRIPTION
r10k used to default to 'master' when no ref / branch was provided.  It
now raise an error, which break CI in onceover:
```
Unable to manage Puppetfile content 'nessus_agent_tasks': Could not determine desired ref and no default provided. r10k no longer hardcodes 'master' as the default ref. Consider setting a ref per module in the Puppetfile or setting git:default_ref in your r10k config.
```
